### PR TITLE
html mock to Typescript

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -10,6 +10,6 @@ module.exports = {
   testRegex: "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
   moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
   moduleNameMapper: {
-    "^.+\\.html$": "<rootDir>/src/helpers/html.mock.js"
+    "^.+\\.html$": "<rootDir>/src/helpers/html.mock.ts"
   }
 };

--- a/src/helpers/html.mock.js
+++ b/src/helpers/html.mock.js
@@ -1,1 +1,0 @@
-module.exports = "test-file-stub";

--- a/src/helpers/html.mock.ts
+++ b/src/helpers/html.mock.ts
@@ -1,0 +1,1 @@
+export default "test-file-stub";


### PR DESCRIPTION
# Fixes issue(s)

None but it looks better 💯 

## Proposed changes

- html.mock.js is now a default export typescript file. 
- jest loads the typescript mock now.
